### PR TITLE
Really print version string on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /work
 COPY . .
 RUN make
 
-FROM alpine:3.18
+FROM alpine:3.19
 
 COPY --from=builder /work/bin/metal-console /
 

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func main() {
 		panic(err)
 	}
 
-	log.Info("metal-console", "version", v.V, "port", spec.Port, "metal-api", spec.MetalAPIURL, "devmode", spec.DevMode())
+	log.Info("metal-console", "version", v.V.String(), "port", spec.Port, "metal-api", spec.MetalAPIURL, "devmode", spec.DevMode())
 	s, err := console.NewServer(log, spec, client)
 	if err != nil {
 		log.Error("failed to create console server", "error", err)


### PR DESCRIPTION
Before:

```
metal-console-d764fb6f6-d5699 metal-console {"time":"2024-01-23T10:31:11.844777109Z","level":"INFO","msg":"metal-console","version":{},"port":10001,"metal-api":"http://metal-api:8080/metal/","devmode":false}

```

After:

```
{"time":"2024-01-23T11:34:44.190711826+01:00","level":"INFO","msg":"metal-console","version":"devel (b3360fe5), heads/master-0-gb3360fe, 2024-01-23T11:34:42+01:00, go1.21.6","port":2222,"metal-api":"http://localhost:8080","devmode":false}
```